### PR TITLE
fix release on other branch bug

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
             uses: actions/checkout@v4
             with:
                 fetch-depth: 0
-                ref: main
+                ref: ${{ github.event.inputs.ref || github.ref }}
 
         - 
             name: Login to docker

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 ## for mac-os users
 .DS_Store
-
+AGENTS.md
 ## frontend specific files
 target/


### PR DESCRIPTION
In our original github workflow release.yml, no matter we run action from which branch. *It always only execute main branch code*. I've fixed this one by removing `ref:main` with `ref: ${{ github.event.inputs.ref || github.ref }}`