### PR TITLE
use lib-version VersionUtil in app

### DIFF
--- a/src/main/java/frontend/Main.java
+++ b/src/main/java/frontend/Main.java
@@ -1,12 +1,16 @@
 package frontend;
 
+// Import lib-version and use VersionUtil to print version at startup
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import tudelft.doda2025.team21.VersionUtil;
 
 @SpringBootApplication
 public class Main {
 
     public static void main(String[] args) {
+        System.out.println("lib-version version: " + VersionUtil.getVersion());
         SpringApplication.run(Main.class, args);
     }
 


### PR DESCRIPTION
I've tested by using the newly built docker 0.1.19, which is built from this branch. It works as expected, printing out lib-version version:
<img width="1147" height="404" alt="image" src="https://github.com/user-attachments/assets/9042c440-3344-4027-9a51-64921a1ab500" />
